### PR TITLE
Update DependencyInjection\Configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('cj_codes_slave_route_limiter');
+        $treeBuilder = new TreeBuilder('cj_codes_slave_route_limiter');
+        $rootNode = $treeBuilder->getRootNode();
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for


### PR DESCRIPTION
Update DependencyInjection\Configuration

Replace deprecated TreeBuilder implementation with new one.

```php
use Symfony\Component\Config\Definition\Builder\TreeBuilder;

// Before
$treeBuilder = new TreeBuilder();
$rootNode = $treeBuilder->root('acme_root');
$rootNode->...()->...()->...();

// After
$treeBuilder = new TreeBuilder('acme_root');
$treeBuilder->getRootNode()->...()->...()->...();
```
Reference: [Symfony 4.2 Deprecations](https://symfony.com/blog/new-in-symfony-4-2-important-deprecations)